### PR TITLE
feat: add auto-flush for periodic background metric emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.10.0 (2026-01-24)
+* Added auto-flush feature with `Builder::with_auto_flush()` and `Builder::with_auto_flush_interval()` for periodic background flushing to stdout contributed by Michel Majdalani (MichelMajdalani)
+* Added tokio dependency (time, rt features) for auto-flush background task
+* Refactored Builder::build() to return Collector directly for cleaner code
+
 ## v0.9.0 (2026-01-17)
 * Update lambda_http dependency contributed by Roger Wilson (CaptainJiNX)
 * Correctly error and not block if there is an attempt to send more than 100 histogram values before flushing contributed by Aaron1011

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics_cloudwatch_embedded"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["brianmorin <brianrossmorin@gmail.com>"]
 edition = "2021"
 rust-version = "1.84"
@@ -31,6 +31,7 @@ metrics = "0.24"
 pin-project = { version = "1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tokio = { version = "1", features = ["time", "rt"] }
 tower = { version = "0.5.3", optional = true }
 tracing = "0.1"
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,35 @@ metrics
     .flush(std::io::stdout());
 ```
 
+Auto-Flush Feature
+------------------
+The `auto-flush` feature enables periodic background flushing of metrics to stdout. This is useful for:
+- Long-running Lambda functions where you want intermediate metrics before completion
+- Capturing metrics before a potential timeout or crash
+- Reducing the risk of losing metrics if a function fails
+
+```rust
+// Enable auto-flush with default 30-second interval
+let metrics = metrics_cloudwatch_embedded::Builder::new()
+    .cloudwatch_namespace("MyApplication")
+    .with_auto_flush()
+    .init()
+    .unwrap();
+
+// Or with a custom interval
+use std::time::Duration;
+
+let metrics = metrics_cloudwatch_embedded::Builder::new()
+    .cloudwatch_namespace("MyApplication")
+    .with_auto_flush_interval(Duration::from_secs(15))
+    .init()
+    .unwrap();
+```
+
+Auto-flush requires a tokio runtime (always available since tokio is a dependency).
+The Lambda integration will still perform a final flush at the end of each invocation to capture any
+remaining metrics not picked up by the periodic flush.
+
 AWS Lambda Example
 ------------------
 The [Lambda Runtime](https://crates.io/crates/lambda-runtime) integration feature handles flushing metrics 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ It also provides optional helpers for:
 In your Cargo.toml add:
 ```toml
 metrics = "0.24"
-metrics_cloudwatch_embedded = {  version = "0.9.0", features = ["lambda"] }
+metrics_cloudwatch_embedded = {  version = "0.10.0", features = ["lambda"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "json"] }
 ```
 

--- a/examples/lambda/src/main.rs
+++ b/examples/lambda/src/main.rs
@@ -39,6 +39,8 @@ async fn main() -> Result<(), Error> {
         .lambda_cold_start_span(info_span!("cold start"))
         .lambda_cold_start_metric("ColdStart")
         .with_lambda_request_id("RequestId")
+        // Enable auto-flush for long-running functions (optional, flushes every 30s)
+        .with_auto_flush()
         .init()
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,12 @@ pub use {builder::Builder, collector::Collector};
 #[doc(hidden)]
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// Default interval for auto-flush (30 seconds)
+///
+/// Use with [`Builder::with_auto_flush_interval`] or simply call [`Builder::with_auto_flush`]
+/// which uses this default.
+pub const DEFAULT_AUTO_FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
 mod builder;
 mod collector;
 mod emf;


### PR DESCRIPTION
- Add Builder::with_auto_flush() with 30s default interval
- Add Builder::with_auto_flush_interval() for custom intervals
- Spawn tokio background task with MissedTickBehavior::Skip
- Add tokio dependency (time, rt features)
- Refactor Builder::build() to return Collector directly
- Update documentation and examples